### PR TITLE
Remove 'waitUntil' from publishing plugin configuration

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -264,7 +264,6 @@
                     <configuration>
                         <publishingServerId>central</publishingServerId>
                         <autoPublish>true</autoPublish>
-                        <waitUntil>published</waitUntil>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
Removed the 'waitUntil' configuration from the publishing plugin.