### PR TITLE
Update Boost to v1.92.0

### DIFF
--- a/.github/actions/build_native_library/env_variables/action.yml
+++ b/.github/actions/build_native_library/env_variables/action.yml
@@ -37,10 +37,10 @@ runs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        Write "BOOST_DOWNLOAD_URI=https://downloads.sourceforge.net/project/boost/boost-binaries/1.90.0/boost_1_90_0-msvc-14.3-64.exe"  >> $env:GITHUB_ENV
+        Write "BOOST_DOWNLOAD_URI=https://downloads.sourceforge.net/project/boost/boost-binaries/1.92.0/boost_1_92_0-msvc-14.3-64.exe"  >> $env:GITHUB_ENV
         Write "BOOST_INSTALLER_PATH=$env:RUNNER_TEMP\boost.exe"                                                                         >> $env:GITHUB_ENV
         Write "BOOST_INSTALL_DIR=$env:RUNNER_TEMP\boost"                                                                                >> $env:GITHUB_ENV
-        Write "Boost_DIR=$env:RUNNER_TEMP\boost\lib64-msvc-14.3\cmake\Boost-1.90.0"                                                     >> $env:GITHUB_ENV
+        Write "Boost_DIR=$env:RUNNER_TEMP\boost\lib64-msvc-14.3\cmake\Boost-1.92.0"                                                     >> $env:GITHUB_ENV
 
         Write "SWIG_DOWNLOAD_URI=https://sourceforge.net/projects/swig/files/swigwin/swigwin-4.5.0/swigwin-4.5.0.zip/download"          >> $env:GITHUB_ENV
         Write "SWIG_ZIP_FILE_PATH=$env:RUNNER_TEMP\swigwin-4.5.0.zip"                                                                   >> $env:GITHUB_ENV

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ quantlib_for_maven/
 
 ### Prerequisites
 
-- CMake 4.0.0+, SWIG 4.5.0 (exact), Boost 1.90.0, JDK 17/21/25, Maven 3.8+, Ninja
+- CMake 4.0.0+, SWIG 4.5.0 (exact), Boost 1.92.0, JDK 17/21/25, Maven 3.8+, Ninja
 
 ### Full Build (C++ + SWIG + Java)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ project(quantlib_for_maven VERSION 1.43 LANGUAGES CXX)
 
 # set the Boost and Swig versions we want to use
 # to ensure compatibility across linux, macos and windows builds
-set(QL_MVN_BOOST_VERSION "1.90.0" CACHE STRING "Boost version we want to use to ensure compatibility")
+set(QL_MVN_BOOST_VERSION "1.92.0" CACHE STRING "Boost version we want to use to ensure compatibility")
 set(QL_MVN_SWIG_VERSION "4.5.0" CACHE STRING "Swig version we want to use to ensure compatibility")
 
 # set the QuantLib options the way we need them.

--- a/HOWTO-BUILD-FROM-SOURCE.md
+++ b/HOWTO-BUILD-FROM-SOURCE.md
@@ -7,7 +7,7 @@
 - an up-to-date cpp compiler
 - an up-to-date cmake 
 - Swig version `v4.5.0`
-- Boost C++ libraries version `v1.90.0`
+- Boost C++ libraries version `v1.92.0`
 - OpenJDK version `jdk17`, `jdk21` or `jdk25`
 - an up-to-date Apache Maven
 - an up-to-date ninja build system
@@ -110,7 +110,7 @@ installed on your system:
   libraries installed on your system. Only the header files are required to build the QuantLib SWIG.
 
   We are trying to use the latest version of the Boost C++ libraries.
-  Currently, we build the maven artifact using version `v1.90.0`.
+  Currently, we build the maven artifact using version `v1.92.0`.
 
   See the [Boost C++ Libraries](https://www.boost.org/) website for more information.
 


### PR DESCRIPTION
## Summary

Bumps the pinned Boost version from `v1.90.0` to `v1.92.0`, the current Boost
release.

`cmake/Boost.cmake` resolves Boost with `find_package(Boost ... EXACT)`, so the
pin is not a lower bound — configuring against any other installed Boost fails
outright:

    Could not find a configuration file for package "Boost" that exactly
    matches requested version "1.90.0".
      .../lib/cmake/Boost-1.92.0/BoostConfig.cmake, version: 1.92.0
        The version found is not compatible with the version requested.

Because the pin is exact, every place that names the version has to move with
it:

- `CMakeLists.txt` — `QL_MVN_BOOST_VERSION` is now `1.92.0`
- `.github/actions/build_native_library/env_variables/action.yml` — the Windows
  runner's `BOOST_DOWNLOAD_URI` (SourceForge msvc-14.3 installer) and the
  `Boost_DIR` cmake path, which embeds the version as `cmake\Boost-1.92.0`
- `AGENTS.md` and `HOWTO-BUILD-FROM-SOURCE.md` — the documented prerequisite

Linux and macOS CI install Boost via Homebrew and need no change; Homebrew
stable is already `1.92.0`.

## Related issue(s)

<!-- Add references such as "Closes #123" -->

## Verification

Verified locally on Linux (WSL2) against Homebrew Boost 1.92.0:

- [x] `cmake --preset release` configures and resolves Boost 1.92.0 — this is
      the step that failed before the bump
- [x] `libQuantLib.a` compiles and links against Boost 1.92.0 (all 982 objects,
      no Boost-related warnings or errors)
- [ ] Full `cmake --build --preset release` including SWIG/JNI and `./mvnw
      verify` — still running locally at time of writing
- [ ] Windows CI: confirm the new SourceForge installer URI and `Boost_DIR` path
      resolve on the runner (the URI itself returns HTTP 200)
- [ ] Relevant tests pass locally
