### PR TITLE
Set timezone Europe/Berlin for the stale workflow schedule

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: '0 3 * * *'
+      timezone: "Europe/Berlin"
 
 permissions:
   issues: write


### PR DESCRIPTION
## Summary

- Add `timezone: "Europe/Berlin"` to the `schedule:` trigger in
  `.github/workflows/stale.yml`. Without it, GitHub interprets the cron
  expression as UTC, so the job drifts by an hour relative to local time
  across DST changes.
- This aligns `stale.yml` with `build_with_quantlib_latest.yml`, which already
  pins its schedule to `Europe/Berlin`. Both scheduled workflows now use the
  same timezone year-round.
- The cron value itself is unchanged (`0 3 * * *`), so the job now fires at
  03:00 Berlin time rather than 03:00 UTC.
- Audited the remaining workflows — `build_maven_artefact.yml`,
  `build_native_libraries.yml` and `delete_workflow_caches.yml` have no
  `schedule:` trigger, so there is nothing to set there.

## Test plan

- [ ] YAML parses and the workflow is accepted by GitHub Actions (no
      "invalid workflow file" annotation on this branch)
- [ ] Trigger `Close stale issues and pull requests` via `workflow_dispatch`
      to confirm the workflow still runs
- [ ] After merge, confirm the next scheduled run lands at 03:00 Europe/Berlin

🤖 Generated with [Claude Code](https://claude.com/claude-code)
