### PR TITLE
Keep the Actions cache inside the repository quota

### DIFF
--- a/.github/actions/build_native_library/action.yml
+++ b/.github/actions/build_native_library/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: The java jdk version to setup
     default: ''
     required: true
+  save-ccache:
+    description: Whether this job writes the compiler cache when it runs on master
+    default: 'true'
+    required: false
   gpg-secret-key:
     description: The gpg secret key
     default: ''
@@ -34,6 +38,7 @@ runs:
       with:
         runner-name:    ${{ inputs.runner-name }}
         java-version:   ${{ inputs.java-version }}
+        save-ccache:    ${{ inputs.save-ccache }}
         gpg-secret-key: ${{ inputs.gpg-secret-key }}
 
     - name: Build

--- a/.github/actions/build_native_library/setup/action.yml
+++ b/.github/actions/build_native_library/setup/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: The java jdk version to setup
     default: ''
     required: true
+  save-ccache:
+    description: Whether this job writes the compiler cache when it runs on master
+    default: 'true'
+    required: false
   gpg-secret-key:
     description: The gpg secret key
     default: ''
@@ -118,17 +122,20 @@ runs:
     # created it: only the default branch's entries are restorable from every other branch and pull
     # request. Writing them on topic branches filled the 10GB repository quota with entries no other
     # run could ever read, which evicted master's entries and cost the hits it was meant to save.
-    # Of the three jdk jobs on a runner only jdk17 writes: the jdk version affects the SWIG wrapper
-    # translation unit alone, so the other two would store a near-identical copy of the same cache.
+    # Which of a runner's jdk jobs writes is decided by the caller, next to the matrix defining it.
+    #
+    # A restore key matches by prefix, so no runner's key may be a prefix of another runner's key.
+    # Without the trailing architecture 'Linux-ubuntu-22.04' also matches the entries written by
+    # 'Linux-ubuntu-22.04-arm', and the x64 job would restore aarch64 objects it cannot use.
     - name: Setup CCache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
         variant: ${{ env.CMAKE_CXX_COMPILER_LAUNCHER }}
-        key: ${{ runner.os }}-${{ inputs.runner-name }}
-        restore-keys: ${{ runner.os }}-${{ inputs.runner-name }}
+        key: ${{ runner.os }}-${{ inputs.runner-name }}-${{ runner.arch }}
+        restore-keys: ${{ runner.os }}-${{ inputs.runner-name }}-${{ runner.arch }}
         max-size: 250M
         evict-old-files: 7d
-        save: ${{ github.ref == 'refs/heads/master' && inputs.java-version == '17' }}
+        save: ${{ github.ref == 'refs/heads/master' && inputs.save-ccache == 'true' }}
 
     - name: Set up Visual Studio shell on Windows
       uses: TheMrMilchmann/setup-msvc-dev@v4

--- a/.github/actions/build_native_library/setup/action.yml
+++ b/.github/actions/build_native_library/setup/action.yml
@@ -114,14 +114,21 @@ runs:
         java-version:   ${{ inputs.java-version }}
         gpg-secret-key: ${{ inputs.gpg-secret-key }}
 
+    # Compiler caches are only written on master, because GitHub scopes a cache to the branch that
+    # created it: only the default branch's entries are restorable from every other branch and pull
+    # request. Writing them on topic branches filled the 10GB repository quota with entries no other
+    # run could ever read, which evicted master's entries and cost the hits it was meant to save.
+    # Of the three jdk jobs on a runner only jdk17 writes: the jdk version affects the SWIG wrapper
+    # translation unit alone, so the other two would store a near-identical copy of the same cache.
     - name: Setup CCache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
         variant: ${{ env.CMAKE_CXX_COMPILER_LAUNCHER }}
         key: ${{ runner.os }}-${{ inputs.runner-name }}
-        restore-keys: |
-          ${{ runner.os }}-${{ inputs.runner-name }}
-          ${{ runner.os }}
+        restore-keys: ${{ runner.os }}-${{ inputs.runner-name }}
+        max-size: 250M
+        evict-old-files: 7d
+        save: ${{ github.ref == 'refs/heads/master' && inputs.java-version == '17' }}
 
     - name: Set up Visual Studio shell on Windows
       uses: TheMrMilchmann/setup-msvc-dev@v4

--- a/.github/workflows/build_maven_artefact.yml
+++ b/.github/workflows/build_maven_artefact.yml
@@ -1,7 +1,9 @@
 name: Build the QuantLib maven artefact
 
 on:
-  push: {}
+  push:
+    branches:
+      - master
   pull_request: {}
   workflow_dispatch: {}
 

--- a/.github/workflows/build_maven_artefact.yml
+++ b/.github/workflows/build_maven_artefact.yml
@@ -38,11 +38,13 @@ jobs:
         with:
           submodules: "true"
 
+      # Only the jdk17 job of a runner writes the compiler cache; see build_native_libraries.yml.
       - name: Build native library for ${{ runner.os }}
         uses: ./.github/actions/build_native_library
         with:
           runner-name: ${{ matrix.os }}
           java-version: ${{ matrix.java-version }}
+          save-ccache: ${{ matrix.java-version == 17 }}
           gpg-secret-key: ${{ secrets.GPG_SECRET_KEY }}
           gpg-secret-key-password: ${{ secrets.GPG_SECRET_KEY_PASSWORD }}
           upload-path: ${{ env.JAVA_RESOURCES_NATIVE_LIBS_PATH }}
@@ -102,11 +104,13 @@ jobs:
         run: |
           ./mvnw --batch-mode --show-version versions:set -DnewVersion=${{ env.QUANTLIB_VERSION }}
 
+      # Only the jdk17 job of a runner writes the compiler cache; see build_native_libraries.yml.
       - name: Build native library for ${{ runner.os }} and jdk ${{ matrix.java-version }}
         uses: ./.github/actions/build_native_library
         with:
           runner-name: ${{ matrix.os }}
           java-version: ${{ matrix.java-version }}
+          save-ccache: ${{ matrix.java-version == 17 }}
           gpg-secret-key: ${{ secrets.GPG_SECRET_KEY }}
           gpg-secret-key-password: ${{ secrets.GPG_SECRET_KEY_PASSWORD }}
 

--- a/.github/workflows/build_native_libraries.yml
+++ b/.github/workflows/build_native_libraries.yml
@@ -2,15 +2,16 @@ name: Build for different runners
 
 on:
   push:
-    branches-ignore:
+    branches:
       - master
   pull_request: {}
   workflow_dispatch: {}
 
-# Do not let a new push race the previous run's jobs.
+# Do not let a new push race the previous run's jobs, but never cancel a run on master: that is
+# the branch whose ccache entries every other branch and pull request restores from.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   build-native:

--- a/.github/workflows/build_native_libraries.yml
+++ b/.github/workflows/build_native_libraries.yml
@@ -42,10 +42,14 @@ jobs:
         with:
           submodules: "true"
 
+      # Of the three jdk jobs on a runner only the jdk17 one writes the compiler cache: the jdk
+      # version affects the SWIG wrapper translation unit alone, so the other two would store a
+      # near-identical copy of the same cache. Keep this in step with the matrix baseline above.
       - name: Build native library for ${{ matrix.os }} and jdk${{ matrix.java-version }}
         uses: ./.github/actions/build_native_library
         with:
           runner-name: ${{ matrix.os }}
           java-version: ${{ matrix.java-version }}
+          save-ccache: ${{ matrix.java-version == 17 }}
           gpg-secret-key: ${{ secrets.GPG_SECRET_KEY }}
           gpg-secret-key-password: ${{ secrets.GPG_SECRET_KEY_PASSWORD }}

--- a/.github/workflows/cleanup_workflow_caches.yml
+++ b/.github/workflows/cleanup_workflow_caches.yml
@@ -3,8 +3,12 @@ name: Cleanup workflow caches
 # GitHub never reclaims the caches of a merged pull request or a deleted branch on its own, so they
 # keep counting against the 10GB repository quota until they are evicted. Once evicted, the entries
 # that are still in use go with them, and the next build recompiles from scratch.
+#
+# The trigger is 'pull_request_target' and not 'pull_request': for a pull request from a fork the
+# 'pull_request' token stays read-only no matter what the workflow asks for in 'permissions', and
+# every deletion would fail with 403. Nothing from the pull request is checked out or run here.
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
   delete: {}
@@ -12,45 +16,19 @@ on:
 permissions:
   actions: write
 
-# Deleting caches for one ref must not race the deletion for another ref.
+# Deleting the caches of one ref must not race a second run for the same ref. The group is keyed by
+# ref rather than by workflow: with a single repository-wide group, merging two pull requests in a
+# row cancels the queued run of the first one, and its caches are never deleted.
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.ref }}
 
 jobs:
   cleanup-workflow-caches:
     name: Delete the caches of the closed pull request or the deleted branch
     if: github.event_name != 'delete' || github.event.ref_type == 'branch'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Delete the caches of the obsolete ref
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const ref = context.eventName === 'delete'
-              ? `refs/heads/${context.payload.ref}`
-              : `refs/pull/${context.issue.number}/merge`;
-
-            const caches = await github.paginate(
-              github.rest.actions.getActionsCacheList,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: ref,
-              },
-              (response) => response.data
-            );
-
-            core.info(`Found ${caches.length} cache entries for ${ref}.`);
-
-            for (const cache of caches) {
-              try {
-                await github.rest.actions.deleteActionsCacheById({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  cache_id: cache.id,
-                });
-                core.info(`Deleted cache id ${cache.id} (${cache.key}).`);
-              } catch (error) {
-                core.warning(`Could not delete cache id ${cache.id} (${cache.key}): ${error.message}`);
-              }
-            }
+    uses: ./.github/workflows/delete_workflow_caches.yml
+    with:
+      ref: >-
+        ${{ github.event_name == 'delete'
+        && format('refs/heads/{0}', github.event.ref)
+        || format('refs/pull/{0}/merge', github.event.pull_request.number) }}

--- a/.github/workflows/cleanup_workflow_caches.yml
+++ b/.github/workflows/cleanup_workflow_caches.yml
@@ -1,0 +1,56 @@
+name: Cleanup workflow caches
+
+# GitHub never reclaims the caches of a merged pull request or a deleted branch on its own, so they
+# keep counting against the 10GB repository quota until they are evicted. Once evicted, the entries
+# that are still in use go with them, and the next build recompiles from scratch.
+on:
+  pull_request:
+    types:
+      - closed
+  delete: {}
+
+permissions:
+  actions: write
+
+# Deleting caches for one ref must not race the deletion for another ref.
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  cleanup-workflow-caches:
+    name: Delete the caches of the closed pull request or the deleted branch
+    if: github.event_name != 'delete' || github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete the caches of the obsolete ref
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const ref = context.eventName === 'delete'
+              ? `refs/heads/${context.payload.ref}`
+              : `refs/pull/${context.issue.number}/merge`;
+
+            const caches = await github.paginate(
+              github.rest.actions.getActionsCacheList,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: ref,
+              },
+              (response) => response.data
+            );
+
+            core.info(`Found ${caches.length} cache entries for ${ref}.`);
+
+            for (const cache of caches) {
+              try {
+                await github.rest.actions.deleteActionsCacheById({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  cache_id: cache.id,
+                });
+                core.info(`Deleted cache id ${cache.id} (${cache.key}).`);
+              } catch (error) {
+                core.warning(`Could not delete cache id ${cache.id} (${cache.key}): ${error.message}`);
+              }
+            }

--- a/.github/workflows/delete_workflow_caches.yml
+++ b/.github/workflows/delete_workflow_caches.yml
@@ -2,30 +2,44 @@ name: Delete workflow caches
 
 on:
   workflow_dispatch: {}
+  workflow_call:
+    inputs:
+      ref:
+        description: The ref whose caches to delete; every cache of the repository if left empty
+        type: string
+        default: ''
+        required: false
 
 permissions:
   actions: write
 
 jobs:
   delete-workflow-caches:
-    name: Delete all workflow caches
+    name: Delete the workflow caches
     runs-on: ubuntu-latest
     steps:
-      - name: Delete all caches
+      - name: Delete the caches
         uses: actions/github-script@v9
+        env:
+          CACHE_REF: ${{ inputs.ref }}
         with:
           script: |
+            const ref = process.env.CACHE_REF;
+            const scope = ref ? `for ${ref}` : 'in the repository';
+
             const caches = await github.paginate(
               github.rest.actions.getActionsCacheList,
               {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
+                ...(ref ? { ref } : {}),
               },
               (response) => response.data
             );
 
-            core.info(`Found ${caches.length} cache entries.`);
+            core.info(`Found ${caches.length} cache entries ${scope}.`);
 
+            const undeleted = [];
             for (const cache of caches) {
               try {
                 await github.rest.actions.deleteActionsCacheById({
@@ -35,6 +49,20 @@ jobs:
                 });
                 core.info(`Deleted cache id ${cache.id} (${cache.key}).`);
               } catch (error) {
-                core.warning(`Could not delete cache id ${cache.id} (${cache.key}): ${error.message}`);
+                // Only a concurrent deletion of the same entry is harmless. Every other failure,
+                // a token without 'actions: write' above all, leaves the caches in place and must
+                // not pass as a green run that deleted nothing.
+                if (error.status === 404) {
+                  core.info(`Cache id ${cache.id} (${cache.key}) was already deleted.`);
+                } else {
+                  undeleted.push(cache);
+                  core.error(`Could not delete cache id ${cache.id}: ${error.message}`);
+                }
               }
+            }
+
+            if (undeleted.length > 0) {
+              core.setFailed(
+                `Could not delete ${undeleted.length} of ${caches.length} cache entries.`
+              );
             }


### PR DESCRIPTION
## Summary

The repository held 19.3GB of Actions caches against a 10GB quota, so GitHub was
continuously evicting the least recently used entries — including the ones builds
actually restore from. That is the cause of the missed ccache hits and the longer
build times. Measured from the cache API, almost all of the 19.3GB was waste rather
than cache the builds needed:

| Ref | Size | Entries |
|---|---|---|
| `refs/heads/merge-quantlib-latest-master` (branch long since deleted) | 8.65 GB | 32 |
| `refs/pull/873/merge` | 2.37 GB | 16 |
| `refs/heads/fix-windows-ci-download-failures` (same commits as #873) | 2.37 GB | 16 |
| `refs/pull/872/merge` | 2.21 GB | 14 |
| `refs/pull/871/merge` | 2.10 GB | 14 |
| `refs/heads/master` | 1.58 GB | 20 |

- **Scope `push` to master in both build workflows.** Both triggered on `push` and
  `pull_request`, and because the concurrency group keys on `github.ref` — which
  differs between `refs/heads/<branch>` and `refs/pull/<n>/merge` — neither run
  cancelled the other. Every push to a branch with an open pull request built the
  same commit twice and stored two full sets of caches; the two 2.37GB rows above
  are the same work twice. `pull_request` covers branches on its own.

- **Run `build_native_libraries` on master.** GitHub scopes a cache to the branch
  that created it, and only the default branch's entries are restorable from every
  other branch and pull request. That workflow was `branches-ignore: master`, so the
  six runners it covers (`ubuntu-24.04`, `-arm`, `macos-15`, `macos-15-intel`,
  `macos-26`, `windows-2025`) had no master-scoped entry at all: every pull request
  started cold, wrote ~2.4GB, and that 2.4GB then benefited no other run. It keeps
  `cancel-in-progress` for branches but not for master, which now seeds the caches
  everything else restores from.

- **Only save compiler caches on master, and only from the baseline jdk job.**
  Topic-branch entries filled the quota with caches no other run could read. The three
  jdk jobs on `ubuntu-24.04` also shared one ccache key and each wrote a near-identical
  copy of the same cache (4.03GB across 18 entries); the jdk version affects the SWIG
  wrapper translation unit alone, so the other two have nothing of their own to store.
  Which jdk writes is passed in as a `save-ccache` input from each workflow, next to the
  matrix that defines the baseline.

- **Cap and prune the caches themselves.** Without `max-size` they grew without
  bound — 322MB for ccache and 728MB for the Windows sccache. Now `max-size: 250M`
  (which the action maps to `SCCACHE_CACHE_SIZE` for the sccache variant) plus
  `evict-old-files: 7d`. The `restore-keys` fallback on `${{ runner.os }}` is also
  gone: it let a `macos-26` job restore `macos-14`'s cache, whose objects it cannot
  hit, and then save the merged result back. The key is `<os>-<runner-name>-<arch>`.

- **Add `cleanup_workflow_caches.yml`.** GitHub never reclaims the caches of a merged
  pull request or a deleted branch, which is why the daily and long since deleted
  `merge-quantlib-latest-master` still held 8.65GB. It deletes `refs/pull/<n>/merge`
  entries when a pull request closes and `refs/heads/<name>` entries on branch
  deletion, skipping tag deletions, by calling `delete_workflow_caches.yml` — which
  gained a `workflow_call` trigger with an optional `ref` so the two share one script.

Expected steady state: 10 runner variants x 250MB x ~2 generations, plus ~0.6GB
`setup-java` and ~0.25GB Windows installer caches — roughly 6GB, with no eviction.
The Boost installer and SWIG archive caches need no change of their own: once `push`
runs on master, the Windows job writes them under `refs/heads/master`, where every
branch can read them, instead of each branch re-downloading 232MB from SourceForge.

## Review fixes (8bc73e8)

A review of the first commit turned up six problems in what it introduced.

- **The restore keys collided between sibling runners.** A restore key is matched as a
  prefix, so `Linux-ubuntu-22.04` also matched the entries written by
  `Linux-ubuntu-22.04-arm`, `Linux-ubuntu-24.04` those of `Linux-ubuntu-24.04-arm`, and
  `macOS-macos-15` those of `macOS-macos-15-intel`. `deploy-quantlib-snapshot` was hit
  deterministically: it `needs` `build-for-deploy`, so the arm entries are always the
  most recent match, and every master run restored aarch64 objects it cannot use and
  then stored the result under its own key — the exact cross-runner pollution dropping
  the `runner.os` fallback was meant to end. The key now ends in `${{ runner.arch }}`,
  which differs in all three pairs, so no runner's key is a prefix of another's.

- **The save gate hardcoded the baseline jdk.** `inputs.java-version == '17'` sat inside
  the shared composite action. Moving the matrix baseline from 17 to 21 — a one-token
  edit nowhere near that condition — would have stopped every cache write, with a green
  build and no error. The decision now comes in from the callers as `save-ccache`.

- **The cleanup workflow's concurrency group cancelled its own queued runs.** A
  repository-wide group lets a newly queued run cancel the pending one, so merging two
  pull requests in a row dropped the first one's cleanup and its caches were never
  deleted. The group is now keyed on the ref, which is what actually must not race.

- **Cleanup could delete nothing for pull requests from forks.** On `pull_request` the
  token stays read-only for fork pull requests regardless of the `permissions` block, so
  every deletion would have failed with 403, been logged as a warning and left the job
  green. The trigger is now `pull_request_target`, and the script fails the job on
  anything other than the 404 of a concurrent deletion.

- **The deletion script was duplicated.** It was a near-verbatim copy of
  `delete_workflow_caches.yml`, which has needed fixing twice already. That workflow now
  has a `workflow_call` trigger with an optional `ref` — empty still means every cache,
  its original `workflow_dispatch` behaviour — and `cleanup_workflow_caches.yml` is a
  four-line caller.

- **One line exceeded the 100-column limit** from `.editorconfig`; it came with the copy.

Notes for the reviewer:

- Pushing to a branch with no open pull request now runs no CI until the pull request
  is opened. `workflow_dispatch` remains as the escape hatch.
- `pull_request_target` grants a writable token to the base branch's copy of the
  workflow. That is safe here because the workflow checks out nothing and runs nothing
  from the pull request — it only calls the cache API — but the trigger is a well-known
  footgun in general, so it is worth a second look.
- This does not shrink the existing 19.3GB, since the cleanup workflow only fires on
  future pull request closes and branch deletions. Running the existing
  `delete_workflow_caches.yml` once after this merges clears the slate, at the cost of
  one cold build per runner on the next master push — which then becomes the seed.

## Related issue(s)

<!-- none -->

## Verification

- [ ] Build passes locally
- [ ] Relevant tests pass locally

CI-configuration only; there is no local build or test that exercises it. What was
checked instead:

- All six YAML files parse.
- `save`, `max-size` and `evict-old-files` verified against
  `hendrikmuhs/ccache-action`'s own `action.yml` and `src/`, rather than assumed:
  `save: false` takes an early return in the post step, `max-size` becomes
  `SCCACHE_CACHE_SIZE` for sccache, and `evict-old-files` is ccache-only and silently
  skipped for sccache (where `max-size` does the bounding).
- The duplicate-run diagnosis was confirmed against `gh run list`, which shows four
  runs per branch push (both workflows, on both `push` and `pull_request`).
- The shared deletion script was exercised against a mocked cache API: the `ref` is
  passed through when set and omitted when empty, a 403 fails the job, and a 404 is
  tolerated as a concurrent deletion.
- The build workflows' cache behaviour is observable on this PR's own runs, though the
  first runs after the key change are cold by construction — the architecture suffix
  invalidates every existing entry. The cleanup workflow is not observable here: both
  `pull_request_target` and the local `workflow_call` resolve against the default
  branch, so they take effect only once this merges.
