### PR TITLE
Cut the recurring annotation noise out of the CI runs

### DIFF
--- a/.github/actions/build_native_library/setup/action.yml
+++ b/.github/actions/build_native_library/setup/action.yml
@@ -41,13 +41,41 @@ runs:
         brew update
         brew install boost cmake swig
 
+    # The runner images preinstall third-party taps that Homebrew now refuses to load: aws/tap on
+    # every image and hashicorp/tap on the Intel one, whose vagrant formula fails to import and is
+    # reported as a failed annotation on runs that otherwise succeed. Nothing here uses either tap,
+    # so untap them rather than setting HOMEBREW_NO_REQUIRE_TAP_TRUST, which Homebrew announces it
+    # will remove.
+    #
+    # The images also already ship boost, cmake, ninja and swig, so install only what is missing
+    # and upgrade only what is outdated. Running 'brew install' over all four warned about every
+    # preinstalled one, and an unconditional 'brew upgrade' warned about the dependents check.
     - name: Setup macOs
       if: runner.os == 'macOs'
       shell: bash
       run: |
+        for tap in aws/tap hashicorp/tap; do
+          brew untap "${tap}" || true
+        done
+
         brew update
-        brew install boost cmake ninja swig
-        brew upgrade boost cmake ninja swig
+
+        formulae="boost cmake ninja swig"
+
+        missing=""
+        for formula in ${formulae}; do
+          if ! brew list --formula --versions "${formula}" > /dev/null 2>&1; then
+            missing="${missing} ${formula}"
+          fi
+        done
+        if [ -n "${missing}" ]; then
+          brew install --formula ${missing}
+        fi
+
+        outdated="$(brew outdated --formula --quiet ${formulae})"
+        if [ -n "${outdated}" ]; then
+          brew upgrade --formula ${outdated}
+        fi
 
     - name: Restore the cached Boost installer on Windows
       id: cache-boost-installer
@@ -127,8 +155,12 @@ runs:
     # A restore key matches by prefix, so no runner's key may be a prefix of another runner's key.
     # Without the trailing architecture 'Linux-ubuntu-22.04' also matches the entries written by
     # 'Linux-ubuntu-22.04-arm', and the x64 job would restore aarch64 objects it cannot use.
+    #
+    # Pin the patch version instead of tracking the floating 'v1.2' tag: that tag still points at a
+    # commit declaring 'using: node20', so every run was annotated with a Node.js 20 deprecation
+    # warning. Upstream moved the action to node24 in v1.2.24.
     - name: Setup CCache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@v1.2.24
       with:
         variant: ${{ env.CMAKE_CXX_COMPILER_LAUNCHER }}
         key: ${{ runner.os }}-${{ inputs.runner-name }}-${{ runner.arch }}

--- a/.github/actions/build_native_library/setup/action.yml
+++ b/.github/actions/build_native_library/setup/action.yml
@@ -47,6 +47,12 @@ runs:
     # so untap them rather than setting HOMEBREW_NO_REQUIRE_TAP_TRUST, which Homebrew announces it
     # will remove.
     #
+    # Untapping needs both guards. Homebrew writes a GitHub error annotation of its own whenever it
+    # refuses a tap, so discarding the exit status would hide the failure but keep the annotation
+    # this step exists to remove. It refuses a tap holding installed formulae - hashicorp/tap ships
+    # packer everywhere and vagrant on the Intel image - hence --force, which uninstalls those
+    # first; nothing here uses them. It also refuses a tap that is not installed, hence the check.
+    #
     # The images also already ship boost, cmake, ninja and swig, so install only what is missing
     # and upgrade only what is outdated. Running 'brew install' over all four warned about every
     # preinstalled one, and an unconditional 'brew upgrade' warned about the dependents check.
@@ -54,8 +60,14 @@ runs:
       if: runner.os == 'macOs'
       shell: bash
       run: |
+        # List the taps once instead of piping 'brew tap' into 'grep -q' per tap: '-q' exits on the
+        # first match and can leave 'brew tap' writing to a closed pipe, which 'pipefail' would
+        # turn into a failing condition on exactly the taps that do need untapping.
+        installed_taps="$(brew tap)"
         for tap in aws/tap hashicorp/tap; do
-          brew untap "${tap}" || true
+          if grep -qxF "${tap}" <<< "${installed_taps}"; then
+            brew untap --force "${tap}"
+          fi
         done
 
         brew update
@@ -72,7 +84,10 @@ runs:
           brew install --formula ${missing}
         fi
 
-        outdated="$(brew outdated --formula --quiet ${formulae})"
+        # 'brew outdated' sets a failing exit status when it is given names and one of them is
+        # outdated, and the runner runs this step under 'bash -eo pipefail', where a command
+        # substitution failing inside an assignment aborts the whole step.
+        outdated="$(brew outdated --formula --quiet ${formulae} || true)"
         if [ -n "${outdated}" ]; then
           brew upgrade --formula ${outdated}
         fi

--- a/.github/actions/build_native_library/setup/jdk/action.yml
+++ b/.github/actions/build_native_library/setup/jdk/action.yml
@@ -31,14 +31,14 @@ runs:
     - uses: actions/setup-java@v6
       if: env.JAVA_IS_SETUP != 'true'
       with:
-        java-version:    ${{ inputs.java-version }}
-        distribution:    "temurin"
-        server-id:       central
-        server-username: MAVEN_CENTRAL_USERNAME
-        server-password: MAVEN_CENTRAL_PASSWORD
-        gpg-private-key: ${{ inputs.gpg-secret-key }}
-        gpg-passphrase:  MAVEN_GPG_PASSPHRASE
-        cache:           maven
+        java-version:            ${{ inputs.java-version }}
+        distribution:            "temurin"
+        server-id:               central
+        server-username-env-var: MAVEN_CENTRAL_USERNAME
+        server-password-env-var: MAVEN_CENTRAL_PASSWORD
+        gpg-private-key:         ${{ inputs.gpg-secret-key }}
+        gpg-passphrase-env-var:  MAVEN_GPG_PASSPHRASE
+        cache:                   maven
 
     - id: set_JAVA_IS_SETUP_var
       shell: bash


### PR DESCRIPTION
## Summary

The workflow runs between 2026-08-26 and 2026-09-02 carried 1432 annotations across
48 runs. Roughly 1390 of them trace back to three avoidable sources in
`.github/actions/build_native_library/`, all fixed here.

- **Pin `hendrikmuhs/ccache-action` to `v1.2.24`** (236 annotations, 46 of 48 runs).
  The floating `v1.2` tag still resolves to `e42e668`, whose `action.yml` declares
  `using: "node20"`, so the runner forced the action onto Node.js 24 and annotated
  every job about it. Upstream switched the action to `node24` in `v1.2.24`.

- **Use the `-env-var` inputs of `actions/setup-java`** (626 annotations, 42 of 48
  runs). `server-username`, `server-password` and `gpg-passphrase` are deprecated
  aliases in v6, and each annotated every job that set up a jdk. Only the input
  names change — the environment variables they name are the same ones the deploy
  step and the `env_variables` action already export, so no secret or variable
  wiring is touched.

- **Untap the preinstalled third-party Homebrew taps** (127 warnings plus 14
  failure-level annotations). Homebrew refuses to load `aws/tap` on every macOS
  image and `hashicorp/tap` on the Intel one, whose `vagrant.rb` fails to import.
  That import error is emitted at `annotation_level: failure`, so it painted a red
  ✗ on the summary of 13 runs whose jobs actually succeeded. Untapping is preferred
  over `HOMEBREW_NO_REQUIRE_TAP_TRUST`, which Homebrew announces it will remove.

- **Only install missing and upgrade outdated formulae on macOS** (300 + 83
  annotations). The runner images already ship boost, cmake, ninja and swig, so
  running `brew install` over all four warned about every preinstalled one, and the
  unconditional `brew upgrade` warned about the skipped dependents check.

The Linux setup step also calls `brew update && brew install`, but it produced no
annotations — Linuxbrew has neither tap — so it is left alone.

Not included: retiring the `macos-15-intel` matrix entry. Homebrew dropped macOS
Intel x86_64 support in September 2026 and GitHub drops the Intel runners in 2027,
which accounts for 7 further annotations, but that is a decision about which
platforms to compile-check rather than annotation cleanup.

## Test plan

- [x] Both action files parse as YAML with step order and inputs intact
- [x] The rewritten macOS `run` block passes `bash -n`
- [x] `server-username-env-var`, `server-password-env-var` and
      `gpg-passphrase-env-var` all exist in `actions/setup-java` at the `v6` tag the
      action pins, not only on its default branch
- [x] `ccache-action@v1.2.24` declares `using: "node24"`
- [x] No new line exceeds the 100-column `.editorconfig` limit
- [ ] CI is green on all runners of both build workflows
- [ ] The macOS jobs install/upgrade correctly with the taps removed, and no longer
      report the `vagrant.rb` failure annotation
- [ ] A run on `master` still deploys the snapshot, confirming the renamed
      `setup-java` inputs kept the Maven Central credentials and GPG passphrase
      wiring working

🤖 Generated with [Claude Code](https://claude.com/claude-code)
