### PR TITLE
Restrict deployment to master and disambiguate the deploy job names

### DIFF
--- a/.github/workflows/build_maven_artefact.yml
+++ b/.github/workflows/build_maven_artefact.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
   pull_request: {}
+  # A manual run builds on whatever ref it is started from, but only a run on master deploys: the
+  # steps below require 'github.ref' to be master instead of accepting any dispatch. Picking a
+  # branch in the 'Run workflow' dropdown must not publish the snapshot from unreviewed code.
   workflow_dispatch: {}
 
 # Do not let a new push race the previous run's jobs, but never cancel a run on master:
@@ -21,7 +24,11 @@ env:
 
 jobs:
   build-for-deploy:
-    name: Build for deployment (jdk${{ matrix.java-version }} on ${{ matrix.os }})
+    # Named distinctly from 'deploy-quantlib-snapshot' below, which branch protection requires by
+    # name as 'Build for deployment (jdk17 on ubuntu-22.04)'. Both jobs rendered this one template
+    # and stayed distinguishable only because their matrices happened to use disjoint 'os' values,
+    # so adding ubuntu-22.04 here would have made the required check ambiguous.
+    name: Build native library for deployment (jdk${{ matrix.java-version }} on ${{ matrix.os }})
     # This job only compiles and uploads an artifact, so it does not need the repository default,
     # which is a read-write GITHUB_TOKEN. 'deploy-quantlib-snapshot' below narrows it too.
     permissions:
@@ -78,7 +85,7 @@ jobs:
       # the build path deliberately tolerates a missing key so that pull requests from forks,
       # which are given no secrets at all, can still run.
       - name: Check the signing secrets are available
-        if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/master'
         env:
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SECRET_KEY_PASSWORD: ${{ secrets.GPG_SECRET_KEY_PASSWORD }}
@@ -135,7 +142,7 @@ jobs:
           gpg-secret-key-password: ${{ secrets.GPG_SECRET_KEY_PASSWORD }}
 
       - name: Deploy the maven module
-        if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/master'
         env:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_SECRET_KEY_PASSWORD }}
           MAVEN_CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -144,7 +151,11 @@ jobs:
         run: |
           ./mvnw --batch-mode --show-version clean deploy -P enable-gpg-plugin
 
+      # Gated like the deploy step above. Ungated, every pull request run left a 78 MiB artifact
+      # named exactly like the published snapshot but with no '.asc' signatures, because the deploy
+      # step that produces them is gated - a look-alike for anyone who downloaded it.
       - name: Upload quantlib-${{ env.QUANTLIB_VERSION }}
+        if: github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@v7
         with:
           name: quantlib-${{ env.QUANTLIB_VERSION }}


### PR DESCRIPTION
## Summary

The small half of the follow-ups left open by #882. All four are decisions taken
deliberately; the toolchain-pinning work (the Homebrew version check plus a nightly
bump PR, and pinning `versions-maven-plugin`) follows in a second PR.

- **Deployment now requires master.** `workflow_dispatch` has no branch restriction, and
  the deploy step accepted any dispatch event — so picking a feature branch in the
  *Run workflow* dropdown published that branch to Maven Central as `1.44.0-SNAPSHOT`,
  overwriting the mutable snapshot with unreviewed code. Both gated steps now test
  `github.ref` alone. A manual run still builds from any ref, and still deploys when
  started from master.

- **The artifact upload is gated.** It had no `if:` at all, so every PR run left a 78 MiB
  artifact named exactly like the published snapshot — verified on #882's run. Its `.asc`
  signatures are produced by the *gated* deploy step and were therefore missing, making it
  a look-alike for anyone who downloaded it. Gating it also makes all three conditions in
  the job identical.

- **`build-for-deploy` renamed.** Both jobs rendered one `name` template and stayed
  distinguishable only because their matrices happened to use disjoint `os` values. Branch
  protection requires the *deploy* job's rendering, `Build for deployment (jdk17 on
  ubuntu-22.04)`, so renaming that one would have blocked every merge until the protection
  rule was updated in step. The upstream job is renamed instead — it is not a required
  check, so this needs no protection change.

- **Stale labels created** (no diff). `stale.yml` exempts `help wanted,in progress,no-stale`,
  but `gh label list` showed only `help wanted` existed, leaving the documented escape hatch
  inert. `no-stale` and `in progress` now exist, so all three exemptions resolve.

## Related issue(s)

Follow-up to #882.

## Verification

`build_maven_artefact.yml` parses, no line over 100 characters, no trailing whitespace.

The gating changes are all in steps that do not run on a pull request, so this PR's own CI
exercises the *negative* case only — it confirms the build still passes with deploy, secrets
check and upload skipped. What it cannot confirm is the positive path; that is first exercised
by the push to master after merge, where the deploy must still run and upload the signed
artifact as before.

Worth watching on that first master run: the job rename means `Build native library for
deployment (…)` appears as a new check name and the old name disappears for those three jobs.
Branch protection does not reference them, so no rule needs updating — but the change will be
visible in the checks list.

- [ ] Build passes locally
- [ ] Relevant tests pass locally
- [ ] All required checks pass on this PR
- [ ] After merge: the master run still deploys and uploads the signed artifact
- [ ] After merge: a `workflow_dispatch` from a non-master branch builds but does not deploy
