### PR TITLE
Make CMakeLists.txt the single source of the pinned toolchain versions

### DIFF
--- a/.github/actions/build_native_library/env_variables/action.yml
+++ b/.github/actions/build_native_library/env_variables/action.yml
@@ -48,17 +48,32 @@ runs:
       run: |
         echo "CXXFLAGS=-stdlib=libc++" >> "$GITHUB_ENV"
 
-    # The Boost and SWIG versions have to match the ones CMakeLists.txt pins in
-    # QL_MVN_BOOST_VERSION / QL_MVN_SWIG_VERSION, because both are looked up with an EXACT
-    # find_package(). Keep them in one variable each rather than spread over the URLs and paths
-    # below: bumping SWIG once already missed a copy here and broke every Windows job.
+    # Read both versions out of CMakeLists.txt instead of repeating them here. They are looked up
+    # with an EXACT find_package(), so a copy that drifts from QL_MVN_BOOST_VERSION /
+    # QL_MVN_SWIG_VERSION breaks the Windows build at configure time - bumping SWIG once already
+    # missed a copy in this file and broke every Windows job. CMakeLists.txt is the single source
+    # of truth, which is also the only file 'bump_toolchain_versions.yml' has to edit.
     - name: Setup installation directories on Windows
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        $boostVersion = "1.92.0"
+        $cmakeLists = Get-Content "${env:GITHUB_WORKSPACE}\CMakeLists.txt" -Raw
+
+        # Fail here rather than letting an empty version through: an unmatched regex would
+        # otherwise build 'swigwin-.zip' URLs that 404 much later in the Setup step.
+        $boostVersion = [regex]::Match(
+            $cmakeLists, 'QL_MVN_BOOST_VERSION "([^"]+)"').Groups[1].Value
+        if (-not $boostVersion) {
+            throw "Could not read QL_MVN_BOOST_VERSION from CMakeLists.txt"
+        }
+
+        $swigVersion = [regex]::Match(
+            $cmakeLists, 'QL_MVN_SWIG_VERSION "([^"]+)"').Groups[1].Value
+        if (-not $swigVersion) {
+            throw "Could not read QL_MVN_SWIG_VERSION from CMakeLists.txt"
+        }
+
         $boostUnderscored = $boostVersion.Replace(".", "_")
-        $swigVersion = "4.5.1"
 
         $sourceforge = "https://downloads.sourceforge.net/project"
         $boostFile = "boost_${boostUnderscored}-msvc-14.3-64.exe"

--- a/.github/actions/build_native_library/setup/action.yml
+++ b/.github/actions/build_native_library/setup/action.yml
@@ -97,6 +97,53 @@ runs:
           brew upgrade --formula ${outdated}
         fi
 
+    # Homebrew always installs the current formula, but both find_package() calls ask for the
+    # pinned version with EXACT, so the day a formula moves ahead of CMakeLists.txt every Linux and
+    # macOS job fails - which is what the last SWIG bump was. Compare them here, where the message
+    # can say what to do, rather than letting it surface as an opaque CMake discovery error deep in
+    # the Build step. 'bump_toolchain_versions.yml' opens the bump pull request nightly, so this
+    # normally only fires while that pull request is still open.
+    #
+    # Homebrew appends a revision suffix such as '1.92.0_2' when it rebuilds a formula without an
+    # upstream version change, which is still the same release, so compare only the part before the
+    # underscore. 'grep -P' is GNU-only and the macOS runners ship BSD grep, hence sed.
+    - name: Check the toolchain matches the versions CMakeLists.txt pins
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        read_pin() {
+          sed -n "s/.*${1} \"\([^\"]*\)\".*/\1/p" "${GITHUB_WORKSPACE}/CMakeLists.txt"
+        }
+
+        mismatch=""
+
+        # The runner runs this step under 'bash -eo pipefail', where a failing command
+        # substitution aborts the whole step, so absorb the failure and report the empty result
+        # below: a missing formula should reach the message this step exists to print.
+        boost_want="$(read_pin QL_MVN_BOOST_VERSION)"
+        boost_have="$(brew list --versions boost | awk '{ print $2 }' | cut -d '_' -f 1 || true)"
+        if [ -z "${boost_have}" ]; then
+          mismatch="${mismatch} boost (not installed, pinned ${boost_want})"
+        elif [ "${boost_want}" != "${boost_have}" ]; then
+          mismatch="${mismatch} boost (installed ${boost_have}, pinned ${boost_want})"
+        fi
+
+        swig_want="$(read_pin QL_MVN_SWIG_VERSION)"
+        swig_have="$(swig -version | awk '/SWIG Version/ { print $3 }' || true)"
+        if [ -z "${swig_have}" ]; then
+          mismatch="${mismatch} swig (not on PATH, pinned ${swig_want})"
+        elif [ "${swig_want}" != "${swig_have}" ]; then
+          mismatch="${mismatch} swig (installed ${swig_have}, pinned ${swig_want})"
+        fi
+
+        if [ -n "${mismatch}" ]; then
+          message="Homebrew does not match CMakeLists.txt:${mismatch}."
+          message="${message} Bump QL_MVN_BOOST_VERSION / QL_MVN_SWIG_VERSION in CMakeLists.txt,"
+          message="${message} or merge the pull request bump_toolchain_versions.yml opened."
+          echo "::error::${message}"
+          exit 1
+        fi
+
     - name: Restore the cached Boost installer on Windows
       id: cache-boost-installer
       if: runner.os == 'Windows'

--- a/.github/workflows/bump_toolchain_versions.yml
+++ b/.github/workflows/bump_toolchain_versions.yml
@@ -1,0 +1,130 @@
+name: Bump the pinned toolchain versions
+
+# CMakeLists.txt pins Boost and SWIG and both are looked up with an EXACT find_package(), while
+# Homebrew always installs the current formula. The day a formula moves ahead of the pin, every
+# Linux and macOS job fails at configure time - which is what the last SWIG bump was. This opens
+# the bump as a reviewable pull request the morning Homebrew publishes it, so the change arrives
+# deliberately instead of as a red build on somebody else's unrelated push.
+#
+# Only CMakeLists.txt is rewritten. It is the single source of truth for the build: the Windows
+# download URLs read the versions back out of it. The prerequisite documentation states the
+# versions in prose and is left to the reviewer, who is pointed at the exact places by the body of
+# the pull request.
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # Deliberately clear of the Dependabot window (01:00-03:00) and of
+    # build_with_quantlib_latest.yml at 01:23, so a failure here is easy to attribute.
+    - cron: '37 4 * * *'
+      timezone: "Europe/Berlin"
+
+# The pull request is opened with REPO_SCOPED_TOKEN, so the GITHUB_TOKEN only has to check the
+# repository out. Without this it would get the repository default, which is read-write.
+permissions:
+  contents: read
+
+jobs:
+  bump-toolchain-versions:
+    name: Compare the pinned versions with Homebrew
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      # No submodules: only CMakeLists.txt is read and rewritten, and checking out QuantLib and
+      # QuantLib-SWIG would cost minutes for nothing.
+      - uses: actions/checkout@v7
+
+      - name: Compare the pinned versions with Homebrew
+        id: compare
+        run: |
+          # Assign first, then eval. 'eval "$(...)"' hides a failing command substitution from
+          # 'set -e', because eval of an empty string exits 0.
+          brew_shellenv="$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          eval "${brew_shellenv}"
+
+          brew update > /dev/null
+
+          read_pin() {
+            sed -n "s/.*${1} \"\([^\"]*\)\".*/\1/p" CMakeLists.txt
+          }
+
+          changed="no"
+          summary=""
+
+          compare_formula() {
+            variable="$1"
+            formula="$2"
+
+            want="$(read_pin "${variable}")"
+            have="$(brew info --json=v2 "${formula}" | jq -r '.formulae[0].versions.stable')"
+
+            # An unmatched pin or a renamed formula would otherwise write an empty version into
+            # CMakeLists.txt and open a pull request that breaks every job.
+            if [ -z "${want}" ]; then
+              echo "::error::Could not read ${variable} from CMakeLists.txt"
+              exit 1
+            fi
+            if [ -z "${have}" ] || [ "${have}" = "null" ]; then
+              echo "::error::Could not read the ${formula} version from Homebrew"
+              exit 1
+            fi
+
+            if [ "${want}" = "${have}" ]; then
+              echo "${variable} is up to date at ${want}"
+              return
+            fi
+
+            sed -i "s/\(${variable} \"\)[^\"]*\"/\1${have}\"/" CMakeLists.txt
+
+            # Confirm the rewrite landed rather than trusting sed: a pin whose formatting drifts
+            # from the pattern would leave the file untouched and open an empty pull request.
+            if [ "$(read_pin "${variable}")" != "${have}" ]; then
+              echo "::error::Failed to rewrite ${variable} in CMakeLists.txt"
+              exit 1
+            fi
+
+            echo "${variable}: ${want} -> ${have}"
+            changed="yes"
+            summary="${summary}- \`${variable}\`: \`${want}\` to \`${have}\`"$'\n'
+          }
+
+          compare_formula QL_MVN_BOOST_VERSION boost
+          compare_formula QL_MVN_SWIG_VERSION swig
+
+          {
+            echo "changed=${changed}"
+            echo "summary<<TOOLCHAIN_SUMMARY_EOF"
+            printf '%s' "${summary}"
+            echo "TOOLCHAIN_SUMMARY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: peter-evans/create-pull-request@v8
+        if: steps.compare.outputs.changed == 'yes'
+        with:
+          token:     ${{ secrets.REPO_SCOPED_TOKEN }}
+          author:    github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          branch:    bump-toolchain-versions
+          delete-branch: true
+          commit-message: 'Bump the pinned Boost and SWIG versions to match Homebrew'
+          title: 'Bump the pinned Boost and SWIG versions to match Homebrew'
+          body: |
+            Homebrew has moved ahead of the versions `CMakeLists.txt` pins. Both are looked up with
+            an EXACT `find_package()`, so until this is merged every Linux and macOS job fails in
+            the `Check the toolchain matches the versions CMakeLists.txt pins` step.
+
+            ${{ steps.compare.outputs.summary }}
+            Only `CMakeLists.txt` is changed. The Windows download URLs read the versions back out
+            of it, so nothing else in the build needs editing.
+
+            The prerequisite documentation states these versions in prose and is **not** updated
+            automatically. Please check, and update in this pull request if they changed:
+
+            - [ ] `HOWTO-BUILD-FROM-SOURCE.md` (lines 9, 10, 54, 104, 113)
+            - [ ] `AGENTS.md` (prerequisites line)
+            - [ ] `.github/instructions/swig.instructions.md`
+
+            This is an automated PR generated by the
+            [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action.
+
+            Please review the changes before merging.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -297,6 +297,19 @@
                         </execution>
                     </executions>
                 </plugin>
+                <!--
+                    Only ever invoked from the command line, as 'versions:set' in the deploy job.
+                    Declared here so that goal prefix resolves to a pinned version instead of
+                    whatever is newest on Central at that moment: the job that runs it holds the
+                    Central credentials and the gpg key, and rewrites the pom immediately before
+                    the artifact is signed and published. Declaring it also brings it under the
+                    existing Dependabot maven entry, like every other plugin in this file.
+                -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.21.0</version>
+                </plugin>
                 <plugin>
                     <groupId>org.sonatype.central</groupId>
                     <artifactId>central-publishing-maven-plugin</artifactId>


### PR DESCRIPTION
## Summary

The second half of the #882 follow-ups: decisions 1 and 5. Keeps `EXACT` rather than
relaxing it, and makes the toolchain bump arrive as a reviewable PR instead of as a red
build on someone's unrelated push.

**`CMakeLists.txt` becomes the single source of truth**

The versions lived in two places — `CMakeLists.txt:15-16` and, since #882 consolidated the
Windows download URLs, `env_variables/action.yml`. That consolidation fixed the duplication
*within* the file but not *across* the two, which is the same failure mode that broke every
Windows job on the last SWIG bump. The Windows step now parses `QL_MVN_BOOST_VERSION` and
`QL_MVN_SWIG_VERSION` back out of `CMakeLists.txt`, and throws if either regex fails to
match — an unmatched regex would otherwise build `swigwin-.zip` URLs that 404 much later.

**Fail fast, with an actionable message**

A new step on Linux and macOS compares what Homebrew installed against the pins, so a drift
names the file and the variables to change instead of surfacing as an opaque CMake
discovery error deep in the Build step. Details that matter:

- A Homebrew revision suffix (`1.92.0_2`) is the same upstream release and compares equal.
- The step runs under `bash -eo pipefail`, so the comparisons absorb a failing command
  substitution — a missing formula must reach the message, not abort the step before it.
- `grep -P` is GNU-only and the macOS runners ship BSD grep, hence `sed`.

**Nightly bump PR**

`bump_toolchain_versions.yml` compares the pins against Homebrew and opens the bump as a
PR, modelled on `build_with_quantlib_latest.yml` (same `REPO_SCOPED_TOKEN`, same
`contents: read`). It edits `CMakeLists.txt` alone — the Windows URLs follow from it — and
verifies its own rewrite landed rather than trusting `sed`. Scheduled at 04:37 Europe/Berlin,
clear of the Dependabot window and of the 01:23 QuantLib job, so a failure is attributable.

The prerequisite docs state these versions in prose (`HOWTO-BUILD-FROM-SOURCE.md` ×5,
`AGENTS.md`, `.github/instructions/swig.instructions.md`). Rewriting prose with regex across
three different phrasings is fragile, so the PR body lists the exact locations as a checklist
for the reviewer instead.

**`versions-maven-plugin` pinned to 2.21.0**

It was the one plugin `java/pom.xml` did not declare, so `versions:set` resolved whatever was
newest on Central at that moment — in the job that holds the Central credentials and the GPG
key, rewriting the pom immediately before signing. Declaring it also brings it under the
existing Dependabot `maven` entry, like every other plugin.

## Related issue(s)

Follow-up to #882 and #883. Completes the eight items left open there.

## Verification

Everything testable without CI was tested locally:

- [x] Pin extraction (`sed`) returns `1.92.0` / `4.5.1` from the real `CMakeLists.txt`, and the
      PowerShell regex returns the same two values.
- [x] Revision-suffix stripping: `1.92.0`, `1.92.0_2`, `1.92.0_10` all reduce to `1.92.0`.
- [x] The check step, extracted from the YAML and run against fake tools: passes on matching
      versions, exits 1 naming both packages when Homebrew is ahead, and exits 1 with
      "not installed" / "not on PATH" rather than aborting when the tools are absent.
- [x] The bump workflow's `sed` rewrite on a copy of `CMakeLists.txt`: changes only the two
      version strings, leaving the `CACHE STRING` docstrings intact.
- [x] `./mvnw validate` passes — `sortpom` accepts the new plugin's position.
- [x] `./mvnw versions:set` downloads `versions-maven-plugin-2.21.0` specifically, confirming
      the pin takes effect.
- [x] All YAML parses; no added line over 100 characters; no trailing whitespace.

What this PR's CI adds: the new check step runs on every Linux and macOS job, so a green run
confirms Homebrew currently agrees with both pins. What it cannot exercise is
`bump_toolchain_versions.yml`, which only runs on its schedule or by dispatch — see below.

- [ ] Build passes locally
- [ ] Relevant tests pass locally
- [ ] All required checks pass on this PR
- [ ] After merge: dispatch `bump_toolchain_versions.yml` once by hand to confirm it reports
      both versions up to date and opens no PR
