### PR TITLE
Rewrite the .github documentation comments from scratch

### DIFF
--- a/.github/actions/build_native_library/action.yml
+++ b/.github/actions/build_native_library/action.yml
@@ -1,6 +1,8 @@
 name: Build native library for the runner
 description: Build native library for the runner
 
+# Sets the environment up, installs the toolchain and runs the CMake build. Uploading the result
+# is optional and only the deploy pipeline asks for it.
 inputs:
   runner-name:
     description: The runner name to be used for ccache key name
@@ -48,6 +50,8 @@ runs:
         cmake --preset release -L
         cmake --build --parallel --preset release --verbose
 
+    # 'if-no-files-found' has to be 'error': CreateJavaLibraryDirectory.cmake creates the output
+    # tree at configure time, so it exists even when the build wrote nothing into it.
     - name: Upload native library
       if: ${{ inputs.upload-path != '' }}
       uses: actions/upload-artifact@v7

--- a/.github/actions/build_native_library/action.yml
+++ b/.github/actions/build_native_library/action.yml
@@ -48,10 +48,6 @@ runs:
         cmake --preset release -L
         cmake --build --parallel --preset release --verbose
 
-    # 'if-no-files-found' has to be 'error'. CreateJavaLibraryDirectory.cmake creates the output
-    # tree at configure time, so it exists even when the build wrote nothing into it: with the
-    # default 'warn' this job would stay green while creating no artifact, and the failure would
-    # only surface in the deploy job as a missing 'native-library-<os>'.
     - name: Upload native library
       if: ${{ inputs.upload-path != '' }}
       uses: actions/upload-artifact@v7

--- a/.github/actions/build_native_library/env_variables/action.yml
+++ b/.github/actions/build_native_library/env_variables/action.yml
@@ -10,10 +10,6 @@ inputs:
 runs:
   using: composite
   steps:
-    # Pass the secret through the step environment instead of interpolating it into the command
-    # line, and write it with the heredoc form of $GITHUB_ENV. Interpolated, a passphrase holding a
-    # quote, a backtick or '$(...)' would break the step or run as shell, and one holding a newline
-    # would inject a second KEY=VALUE record into the job environment.
     - name: Set the 'MAVEN_GPG_PASSPHRASE'
       shell: bash
       env:
@@ -38,29 +34,18 @@ runs:
       run: |
         echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> "$GITHUB_PATH"
 
-    # No HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK here. It was added to silence the dependents-check
-    # warning from an unconditional 'brew upgrade' that the setup step no longer runs, and Homebrew
-    # warns on every invocation while the variable is set - roughly ten annotations per push, the
-    # exact noise the cleanup it outlived set out to remove.
     - name: Setup build variables on macOs
       if: runner.os == 'macOs'
       shell: bash
       run: |
         echo "CXXFLAGS=-stdlib=libc++" >> "$GITHUB_ENV"
 
-    # Read both versions out of CMakeLists.txt instead of repeating them here. They are looked up
-    # with an EXACT find_package(), so a copy that drifts from QL_MVN_BOOST_VERSION /
-    # QL_MVN_SWIG_VERSION breaks the Windows build at configure time - bumping SWIG once already
-    # missed a copy in this file and broke every Windows job. CMakeLists.txt is the single source
-    # of truth, which is also the only file 'bump_toolchain_versions.yml' has to edit.
     - name: Setup installation directories on Windows
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
         $cmakeLists = Get-Content "${env:GITHUB_WORKSPACE}\CMakeLists.txt" -Raw
 
-        # Fail here rather than letting an empty version through: an unmatched regex would
-        # otherwise build 'swigwin-.zip' URLs that 404 much later in the Setup step.
         $boostVersion = [regex]::Match(
             $cmakeLists, 'QL_MVN_BOOST_VERSION "([^"]+)"').Groups[1].Value
         if (-not $boostVersion) {

--- a/.github/actions/build_native_library/env_variables/action.yml
+++ b/.github/actions/build_native_library/env_variables/action.yml
@@ -10,6 +10,9 @@ inputs:
 runs:
   using: composite
   steps:
+    # Pass the secret through the step environment and write it with the heredoc form of
+    # $GITHUB_ENV. Interpolated, a passphrase holding a quote or a newline would break the step,
+    # run as shell, or inject a second record into the job environment.
     - name: Set the 'MAVEN_GPG_PASSPHRASE'
       shell: bash
       env:
@@ -34,18 +37,24 @@ runs:
       run: |
         echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> "$GITHUB_PATH"
 
+    # No HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK here: the unconditional 'brew upgrade' it silenced
+    # is gone, and Homebrew warns on every invocation while the variable is set.
     - name: Setup build variables on macOs
       if: runner.os == 'macOs'
       shell: bash
       run: |
         echo "CXXFLAGS=-stdlib=libc++" >> "$GITHUB_ENV"
 
+    # Read both versions out of CMakeLists.txt instead of repeating them: they are looked up with
+    # an EXACT find_package(), so a copy that drifts breaks the Windows build at configure time.
     - name: Setup installation directories on Windows
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
         $cmakeLists = Get-Content "${env:GITHUB_WORKSPACE}\CMakeLists.txt" -Raw
 
+        # Fail here rather than letting an empty version through: an unmatched regex would
+        # otherwise build 'swigwin-.zip' URLs that 404 much later in the Setup step.
         $boostVersion = [regex]::Match(
             $cmakeLists, 'QL_MVN_BOOST_VERSION "([^"]+)"').Groups[1].Value
         if (-not $boostVersion) {

--- a/.github/actions/build_native_library/setup/action.yml
+++ b/.github/actions/build_native_library/setup/action.yml
@@ -37,16 +37,29 @@ runs:
         sudo apt-get install -y ccache ninja-build
         sudo apt-get remove -y cmake swig swig4.0
 
+        # Assign first, then eval: 'eval "$(...)"' hides a failing command substitution from
+        # 'set -e', so a moved Homebrew prefix would leave the step green and fail later in CMake.
         brew_shellenv="$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         eval "${brew_shellenv}"
 
         brew update
         brew install boost cmake swig
 
+    # The runner images preinstall taps Homebrew now refuses to load - aws/tap everywhere and
+    # hashicorp/tap on the Intel image - which shows up as a failed annotation on green runs.
+    # Untap them rather than setting HOMEBREW_NO_REQUIRE_TAP_TRUST, which Homebrew will remove.
+    # --force uninstalls the formulae those taps own; nothing here uses them. Guard on the tap
+    # being installed, because Homebrew annotates a refused untap too.
+    #
+    # The images also ship boost, cmake, ninja and swig, so install only what is missing and
+    # upgrade only what is outdated: doing either unconditionally warns about the rest.
     - name: Setup macOs
       if: runner.os == 'macOs'
       shell: bash
       run: |
+        # List the taps once instead of piping 'brew tap' into 'grep -q' per tap: '-q' exits on
+        # the first match and leaves 'brew tap' writing to a closed pipe, which 'pipefail' turns
+        # into a failing condition on exactly the taps that do need untapping.
         installed_taps="$(brew tap)"
         for tap in aws/tap hashicorp/tap; do
           if grep -qxF "${tap}" <<< "${installed_taps}"; then
@@ -68,11 +81,19 @@ runs:
           brew install --formula ${missing}
         fi
 
+        # 'brew outdated' fails when given names and one of them is outdated, and the runner runs
+        # this step under 'bash -eo pipefail'.
         outdated="$(brew outdated --formula --quiet ${formulae} || true)"
         if [ -n "${outdated}" ]; then
           brew upgrade --formula ${outdated}
         fi
 
+    # Homebrew installs the current formula but both find_package() calls ask for the pinned
+    # version with EXACT, so compare here, where the message can say what to do, rather than
+    # letting it surface as an opaque CMake discovery error in the Build step.
+    #
+    # Compare only the part before the underscore: Homebrew appends a revision suffix such as
+    # '1.92.0_2' for a rebuild of the same release. 'grep -P' is GNU-only, hence sed.
     - name: Check the toolchain matches the versions CMakeLists.txt pins
       if: runner.os != 'Windows'
       shell: bash
@@ -83,6 +104,8 @@ runs:
 
         mismatch=""
 
+        # The runner runs this step under 'bash -eo pipefail', so absorb a failing command
+        # substitution and report the empty result below instead of aborting the step.
         boost_want="$(read_pin QL_MVN_BOOST_VERSION)"
         boost_have="$(brew list --versions boost | awk '{ print $2 }' | cut -d '_' -f 1 || true)"
         if [ -z "${boost_have}" ]; then
@@ -127,6 +150,8 @@ runs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
+        # SourceForge mirrors regularly drop the connection. Retry each download, and bound how
+        # long BITS keeps retrying transient errors so a dead mirror fails fast.
         function Invoke-DownloadWithRetry {
             param(
                 [Parameter(Mandatory = $true)] [string] $Uri,
@@ -157,6 +182,8 @@ runs:
                 -Destination $env:BOOST_INSTALLER_PATH
         }
 
+        # Check the installer's exit code: BITS reports a mirror's HTML error page as a successful
+        # transfer, and the step would pass having installed nothing.
         $boostInstall = Start-Process -Wait -PassThru -FilePath "$env:BOOST_INSTALLER_PATH" `
             -ArgumentList "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=$env:BOOST_INSTALL_DIR"
         if ($boostInstall.ExitCode -ne 0) {
@@ -169,6 +196,8 @@ runs:
         }
         Expand-Archive -Force $env:SWIG_ZIP_FILE_PATH $env:RUNNER_TEMP
 
+        # Check the exit status here: only the *last* native command decides the step's own, so
+        # 'choco install' below would overwrite a failure from a truncated SWIG archive.
         swig -version
         if ($LASTEXITCODE -ne 0) {
             throw "'swig -version' failed with exit code $LASTEXITCODE"
@@ -182,6 +211,15 @@ runs:
         java-version:   ${{ inputs.java-version }}
         gpg-secret-key: ${{ inputs.gpg-secret-key }}
 
+    # Compiler caches are only written on master, because GitHub makes only the default branch's
+    # entries restorable from every other branch. Writing them on topic branches filled the 10GB
+    # quota with unreadable entries and evicted master's. Which jdk job writes is up to the caller.
+    #
+    # A restore key matches by prefix, so no runner's key may be a prefix of another's: without
+    # the trailing architecture 'Linux-ubuntu-22.04' also matches the '-arm' runner's entries.
+    #
+    # Pin the patch version: the floating 'v1.2' tag still declares 'using: node20' and annotates
+    # every run with a deprecation warning. Upstream moved to node24 in v1.2.24.
     - name: Setup CCache
       uses: hendrikmuhs/ccache-action@v1.2.24
       with:

--- a/.github/actions/build_native_library/setup/action.yml
+++ b/.github/actions/build_native_library/setup/action.yml
@@ -37,37 +37,16 @@ runs:
         sudo apt-get install -y ccache ninja-build
         sudo apt-get remove -y cmake swig swig4.0
 
-        # Assign first, then eval. 'eval "$(...)"' hides a failing command substitution from
-        # 'set -e' - eval of an empty string exits 0 - so a moved Homebrew prefix would leave
-        # HOMEBREW_PREFIX unset and the step green, and surface later as a CMake discovery error.
         brew_shellenv="$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         eval "${brew_shellenv}"
 
         brew update
         brew install boost cmake swig
 
-    # The runner images preinstall third-party taps that Homebrew now refuses to load: aws/tap on
-    # every image and hashicorp/tap on the Intel one, whose vagrant formula fails to import and is
-    # reported as a failed annotation on runs that otherwise succeed. Nothing here uses either tap,
-    # so untap them rather than setting HOMEBREW_NO_REQUIRE_TAP_TRUST, which Homebrew announces it
-    # will remove.
-    #
-    # Untapping needs both guards. Homebrew writes a GitHub error annotation of its own whenever it
-    # refuses a tap, so discarding the exit status would hide the failure but keep the annotation
-    # this step exists to remove. It refuses a tap holding installed formulae - hashicorp/tap ships
-    # packer everywhere and vagrant on the Intel image - hence --force, which uninstalls those
-    # first; nothing here uses them. It also refuses a tap that is not installed, hence the check.
-    #
-    # The images also already ship boost, cmake, ninja and swig, so install only what is missing
-    # and upgrade only what is outdated. Running 'brew install' over all four warned about every
-    # preinstalled one, and an unconditional 'brew upgrade' warned about the dependents check.
     - name: Setup macOs
       if: runner.os == 'macOs'
       shell: bash
       run: |
-        # List the taps once instead of piping 'brew tap' into 'grep -q' per tap: '-q' exits on the
-        # first match and can leave 'brew tap' writing to a closed pipe, which 'pipefail' would
-        # turn into a failing condition on exactly the taps that do need untapping.
         installed_taps="$(brew tap)"
         for tap in aws/tap hashicorp/tap; do
           if grep -qxF "${tap}" <<< "${installed_taps}"; then
@@ -89,24 +68,11 @@ runs:
           brew install --formula ${missing}
         fi
 
-        # 'brew outdated' sets a failing exit status when it is given names and one of them is
-        # outdated, and the runner runs this step under 'bash -eo pipefail', where a command
-        # substitution failing inside an assignment aborts the whole step.
         outdated="$(brew outdated --formula --quiet ${formulae} || true)"
         if [ -n "${outdated}" ]; then
           brew upgrade --formula ${outdated}
         fi
 
-    # Homebrew always installs the current formula, but both find_package() calls ask for the
-    # pinned version with EXACT, so the day a formula moves ahead of CMakeLists.txt every Linux and
-    # macOS job fails - which is what the last SWIG bump was. Compare them here, where the message
-    # can say what to do, rather than letting it surface as an opaque CMake discovery error deep in
-    # the Build step. 'bump_toolchain_versions.yml' opens the bump pull request nightly, so this
-    # normally only fires while that pull request is still open.
-    #
-    # Homebrew appends a revision suffix such as '1.92.0_2' when it rebuilds a formula without an
-    # upstream version change, which is still the same release, so compare only the part before the
-    # underscore. 'grep -P' is GNU-only and the macOS runners ship BSD grep, hence sed.
     - name: Check the toolchain matches the versions CMakeLists.txt pins
       if: runner.os != 'Windows'
       shell: bash
@@ -117,9 +83,6 @@ runs:
 
         mismatch=""
 
-        # The runner runs this step under 'bash -eo pipefail', where a failing command
-        # substitution aborts the whole step, so absorb the failure and report the empty result
-        # below: a missing formula should reach the message this step exists to print.
         boost_want="$(read_pin QL_MVN_BOOST_VERSION)"
         boost_have="$(brew list --versions boost | awk '{ print $2 }' | cut -d '_' -f 1 || true)"
         if [ -z "${boost_have}" ]; then
@@ -164,9 +127,6 @@ runs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        # Boost and SWIG are downloaded from SourceForge, whose mirrors regularly drop the
-        # connection. Retry each download instead of failing the whole build on the first error,
-        # and bound how long BITS keeps retrying transient errors so a dead mirror fails fast.
         function Invoke-DownloadWithRetry {
             param(
                 [Parameter(Mandatory = $true)] [string] $Uri,
@@ -197,10 +157,6 @@ runs:
                 -Destination $env:BOOST_INSTALLER_PATH
         }
 
-        # Check the installer's exit code. A SourceForge mirror that answers with an HTML error
-        # page is reported as a successful transfer by BITS, and without this the step would pass
-        # having installed nothing - the failure would then surface much later as an unrelated
-        # 'Could not find Boost' in the Build step.
         $boostInstall = Start-Process -Wait -PassThru -FilePath "$env:BOOST_INSTALLER_PATH" `
             -ArgumentList "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=$env:BOOST_INSTALL_DIR"
         if ($boostInstall.ExitCode -ne 0) {
@@ -213,10 +169,6 @@ runs:
         }
         Expand-Archive -Force $env:SWIG_ZIP_FILE_PATH $env:RUNNER_TEMP
 
-        # Check the exit status here rather than relying on the step's own. Only the *last* native
-        # command decides that, so a swig.exe unpacked from a truncated archive would report a
-        # non-zero status, have it overwritten by 'choco install' below, and surface much later as
-        # a SWIG codegen error.
         swig -version
         if ($LASTEXITCODE -ne 0) {
             throw "'swig -version' failed with exit code $LASTEXITCODE"
@@ -230,19 +182,6 @@ runs:
         java-version:   ${{ inputs.java-version }}
         gpg-secret-key: ${{ inputs.gpg-secret-key }}
 
-    # Compiler caches are only written on master, because GitHub scopes a cache to the branch that
-    # created it: only the default branch's entries are restorable from every other branch and pull
-    # request. Writing them on topic branches filled the 10GB repository quota with entries no other
-    # run could ever read, which evicted master's entries and cost the hits it was meant to save.
-    # Which of a runner's jdk jobs writes is decided by the caller, next to the matrix defining it.
-    #
-    # A restore key matches by prefix, so no runner's key may be a prefix of another runner's key.
-    # Without the trailing architecture 'Linux-ubuntu-22.04' also matches the entries written by
-    # 'Linux-ubuntu-22.04-arm', and the x64 job would restore aarch64 objects it cannot use.
-    #
-    # Pin the patch version instead of tracking the floating 'v1.2' tag: that tag still points at a
-    # commit declaring 'using: node20', so every run was annotated with a Node.js 20 deprecation
-    # warning. Upstream moved the action to node24 in v1.2.24.
     - name: Setup CCache
       uses: hendrikmuhs/ccache-action@v1.2.24
       with:

--- a/.github/actions/build_native_library/setup/jdk/action.yml
+++ b/.github/actions/build_native_library/setup/jdk/action.yml
@@ -21,20 +21,12 @@ runs:
         echo "The variable 'java-version' was not set"
         exit 1
 
-    # Warn, do not fail. Both build workflows run on 'pull_request', and a pull request from a
-    # fork is given no secrets, so a hard failure here would break every external contribution
-    # over a key that only the deploy job needs - 'actions/setup-java' just skips the gpg import
-    # when the key is empty. 'deploy-quantlib-snapshot' checks for the signing secrets itself.
     - name: Warn if gpg-secret-key variable is not Set
       if: inputs.gpg-secret-key == ''
       shell: bash
       run: |
         echo "::warning::The variable 'gpg-secret-key' was not set; skipping the gpg key import"
 
-    # The latch is keyed by the requested jdk version, not by a bare boolean: a job that sets up
-    # one jdk and then asks this action for a different one has to run 'setup-java' again. Keyed
-    # only on a boolean the second request was skipped silently, and the build ran against
-    # the first jdk while the step name announced the second.
     - uses: actions/setup-java@v6
       if: env.JAVA_IS_SETUP != inputs.java-version
       with:

--- a/.github/actions/build_native_library/setup/jdk/action.yml
+++ b/.github/actions/build_native_library/setup/jdk/action.yml
@@ -21,12 +21,17 @@ runs:
         echo "The variable 'java-version' was not set"
         exit 1
 
+    # Warn, do not fail: a pull request from a fork is given no secrets, and a hard failure would
+    # break every external contribution over a key only the deploy job needs. 'actions/setup-java'
+    # skips the gpg import when the key is empty, and the deploy job checks for it itself.
     - name: Warn if gpg-secret-key variable is not Set
       if: inputs.gpg-secret-key == ''
       shell: bash
       run: |
         echo "::warning::The variable 'gpg-secret-key' was not set; skipping the gpg key import"
 
+    # The latch is keyed by the requested jdk version, not by a bare boolean: a job that sets up
+    # one jdk and then asks for another has to run 'setup-java' again.
     - uses: actions/setup-java@v6
       if: env.JAVA_IS_SETUP != inputs.java-version
       with:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,6 @@
 version: 2
 updates:
 
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -9,7 +8,6 @@ updates:
       time: "01:00"
       timezone: "Europe/Berlin"
 
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/build_native_library"
     schedule:
@@ -17,7 +15,6 @@ updates:
       time: "01:30"
       timezone: "Europe/Berlin"
 
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/build_native_library/env_variables"
     schedule:
@@ -25,7 +22,6 @@ updates:
       time: "02:00"
       timezone: "Europe/Berlin"
 
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/build_native_library/setup"
     schedule:
@@ -33,7 +29,6 @@ updates:
       time: "02:30"
       timezone: "Europe/Berlin"
 
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/build_native_library/setup/jdk"
     schedule:
@@ -41,7 +36,6 @@ updates:
       time: "03:00"
       timezone: "Europe/Berlin"
 
-  # Maintain dependencies for maven
   - package-ecosystem: "maven"
     directory: "/java"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+# One entry per directory holding action references: Dependabot does not recurse into the nested
+# composite actions. The times are staggered so the pull requests do not all arrive at once.
 version: 2
 updates:
 

--- a/.github/workflows/build_maven_artefact.yml
+++ b/.github/workflows/build_maven_artefact.yml
@@ -5,8 +5,11 @@ on:
     branches:
       - master
   pull_request: {}
+  # A manual run builds whatever ref it is started from, but only master deploys: the deploy
+  # steps below check 'github.ref' themselves.
   workflow_dispatch: {}
 
+# Cancel superseded runs, but never on master: that is the branch the artefact is deployed from.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
@@ -19,6 +22,8 @@ env:
 
 jobs:
   build-for-deploy:
+    # Keep this name distinct from 'deploy-quantlib-snapshot' below, which branch protection
+    # requires by name. Both jobs render the same template and only their matrices tell them apart.
     name: Build native library for deployment (jdk${{ matrix.java-version }} on ${{ matrix.os }})
     permissions:
       contents: read
@@ -38,6 +43,7 @@ jobs:
         with:
           submodules: "true"
 
+      # Only the jdk17 job of a runner writes the compiler cache; see build_native_libraries.yml.
       - name: Build native library for ${{ runner.os }}
         uses: ./.github/actions/build_native_library
         with:
@@ -51,6 +57,8 @@ jobs:
   deploy-quantlib-snapshot:
     name: Build for deployment (jdk${{ matrix.java-version }} on ${{ matrix.os }})
     needs: [build-for-deploy]
+    # Publishing goes to Maven Central through central-publishing-maven-plugin, not to GitHub
+    # Packages, so no step here needs a write scope on the repository.
     permissions:
       contents: read
     strategy:
@@ -63,6 +71,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
+      # Fail here rather than inside maven-gpg-plugin at the very end of the build. The build path
+      # tolerates a missing key on purpose, so that pull requests from forks - which get no
+      # secrets - still run.
       - name: Check the signing secrets are available
         if: github.ref == 'refs/heads/master'
         env:
@@ -129,6 +140,8 @@ jobs:
         run: |
           ./mvnw --batch-mode --show-version clean deploy -P enable-gpg-plugin
 
+      # Gated like the deploy step above: ungated, every pull request left an unsigned artifact
+      # named exactly like the published snapshot.
       - name: Upload quantlib-${{ env.QUANTLIB_VERSION }}
         if: github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@v7
@@ -140,6 +153,8 @@ jobs:
             ${{ env.JAVA_TARGET_PATH }}/*.jar
             ${{ env.JAVA_TARGET_PATH }}/*.asc
 
+      # Delete the per-platform artifacts only after everything consuming them succeeded, so that
+      # 'Re-run failed jobs' can still download them. A failed run leaves them to 'retention-days'.
       - name: Delete native library artifacts
         uses: geekyeggo/delete-artifact@v6
         with:

--- a/.github/workflows/build_maven_artefact.yml
+++ b/.github/workflows/build_maven_artefact.yml
@@ -5,13 +5,8 @@ on:
     branches:
       - master
   pull_request: {}
-  # A manual run builds on whatever ref it is started from, but only a run on master deploys: the
-  # steps below require 'github.ref' to be master instead of accepting any dispatch. Picking a
-  # branch in the 'Run workflow' dropdown must not publish the snapshot from unreviewed code.
   workflow_dispatch: {}
 
-# Do not let a new push race the previous run's jobs, but never cancel a run on master:
-# that is the branch the maven artefact is deployed from.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
@@ -24,13 +19,7 @@ env:
 
 jobs:
   build-for-deploy:
-    # Named distinctly from 'deploy-quantlib-snapshot' below, which branch protection requires by
-    # name as 'Build for deployment (jdk17 on ubuntu-22.04)'. Both jobs rendered this one template
-    # and stayed distinguishable only because their matrices happened to use disjoint 'os' values,
-    # so adding ubuntu-22.04 here would have made the required check ambiguous.
     name: Build native library for deployment (jdk${{ matrix.java-version }} on ${{ matrix.os }})
-    # This job only compiles and uploads an artifact, so it does not need the repository default,
-    # which is a read-write GITHUB_TOKEN. 'deploy-quantlib-snapshot' below narrows it too.
     permissions:
       contents: read
     strategy:
@@ -49,7 +38,6 @@ jobs:
         with:
           submodules: "true"
 
-      # Only the jdk17 job of a runner writes the compiler cache; see build_native_libraries.yml.
       - name: Build native library for ${{ runner.os }}
         uses: ./.github/actions/build_native_library
         with:
@@ -63,11 +51,6 @@ jobs:
   deploy-quantlib-snapshot:
     name: Build for deployment (jdk${{ matrix.java-version }} on ${{ matrix.os }})
     needs: [build-for-deploy]
-    # Publishing goes to Maven Central through central-publishing-maven-plugin, authenticated with
-    # MAVEN_CENTRAL_USERNAME / MAVEN_CENTRAL_PASSWORD; java/pom.xml declares no
-    # <distributionManagement>, so nothing here targets GitHub Packages. This job holds the Central
-    # credentials and the gpg key and runs plugins downloaded from Central, so it should not also
-    # carry a write scope no step consumes.
     permissions:
       contents: read
     strategy:
@@ -80,10 +63,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
-      # Fail before the build rather than inside maven-gpg-plugin at the very end of it. Neither
-      # secret is validated anywhere else: composite actions do not enforce 'required: true', and
-      # the build path deliberately tolerates a missing key so that pull requests from forks,
-      # which are given no secrets at all, can still run.
       - name: Check the signing secrets are available
         if: github.ref == 'refs/heads/master'
         env:
@@ -131,7 +110,6 @@ jobs:
         run: |
           ./mvnw --batch-mode --show-version versions:set -DnewVersion=${{ env.QUANTLIB_VERSION }}
 
-      # Only the jdk17 job of a runner writes the compiler cache; see build_native_libraries.yml.
       - name: Build native library for ${{ runner.os }} and jdk ${{ matrix.java-version }}
         uses: ./.github/actions/build_native_library
         with:
@@ -151,9 +129,6 @@ jobs:
         run: |
           ./mvnw --batch-mode --show-version clean deploy -P enable-gpg-plugin
 
-      # Gated like the deploy step above. Ungated, every pull request run left a 78 MiB artifact
-      # named exactly like the published snapshot but with no '.asc' signatures, because the deploy
-      # step that produces them is gated - a look-alike for anyone who downloaded it.
       - name: Upload quantlib-${{ env.QUANTLIB_VERSION }}
         if: github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@v7
@@ -165,10 +140,6 @@ jobs:
             ${{ env.JAVA_TARGET_PATH }}/*.jar
             ${{ env.JAVA_TARGET_PATH }}/*.asc
 
-      # Delete the per-platform artifacts only once everything that consumes them has succeeded.
-      # Deleting them before the build and the deploy made 'Re-run failed jobs' impossible: the
-      # re-run starts again at the download steps above, and they would no longer find anything.
-      # A failed run leaves them in place instead, where 'retention-days: 1' reclaims them.
       - name: Delete native library artifacts
         uses: geekyeggo/delete-artifact@v6
         with:

--- a/.github/workflows/build_native_libraries.yml
+++ b/.github/workflows/build_native_libraries.yml
@@ -7,16 +7,10 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 
-# Do not let a new push race the previous run's jobs, but never cancel a run on master: that is
-# the branch whose ccache entries every other branch and pull request restores from.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
-# Without this the jobs get the repository default, which is a read-write GITHUB_TOKEN. Nothing
-# here writes anything through the API, but every job runs cmake, mvnw (which downloads and
-# executes plugins from Maven Central), brew/apt/choco and four third-party actions, so the token
-# they are handed should not be able to push to master or delete caches.
 permissions:
   contents: read
 
@@ -49,9 +43,6 @@ jobs:
         with:
           submodules: "true"
 
-      # Of the three jdk jobs on a runner only the jdk17 one writes the compiler cache: the jdk
-      # version affects the SWIG wrapper translation unit alone, so the other two would store a
-      # near-identical copy of the same cache. Keep this in step with the matrix baseline above.
       - name: Build native library for ${{ matrix.os }} and jdk${{ matrix.java-version }}
         uses: ./.github/actions/build_native_library
         with:

--- a/.github/workflows/build_native_libraries.yml
+++ b/.github/workflows/build_native_libraries.yml
@@ -7,10 +7,14 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 
+# Cancel superseded runs, but never on master: that is the branch whose ccache entries every
+# other branch and pull request restores from.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
+# Nothing here writes through the API, but every job runs cmake, mvnw, package managers and
+# third-party actions, so do not hand them the read-write repository default.
 permissions:
   contents: read
 
@@ -43,6 +47,8 @@ jobs:
         with:
           submodules: "true"
 
+      # Of a runner's jdk jobs only the jdk17 one writes the compiler cache: the jdk version
+      # affects the SWIG wrapper translation unit alone. Keep in step with the matrix above.
       - name: Build native library for ${{ matrix.os }} and jdk${{ matrix.java-version }}
         uses: ./.github/actions/build_native_library
         with:

--- a/.github/workflows/build_with_quantlib_latest.yml
+++ b/.github/workflows/build_with_quantlib_latest.yml
@@ -6,6 +6,7 @@ on:
     - cron: '23 1 * * *'
       timezone: "Europe/Berlin"
 
+# The pull request is opened with REPO_SCOPED_TOKEN, so GITHUB_TOKEN only has to check out.
 permissions:
   contents: read
 

--- a/.github/workflows/build_with_quantlib_latest.yml
+++ b/.github/workflows/build_with_quantlib_latest.yml
@@ -6,8 +6,6 @@ on:
     - cron: '23 1 * * *'
       timezone: "Europe/Berlin"
 
-# The pull request is opened with REPO_SCOPED_TOKEN, so the GITHUB_TOKEN only has to check the
-# repository out. Without this it would get the repository default, which is read-write.
 permissions:
   contents: read
 

--- a/.github/workflows/bump_toolchain_versions.yml
+++ b/.github/workflows/bump_toolchain_versions.yml
@@ -1,26 +1,11 @@
 name: Bump the pinned toolchain versions
 
-# CMakeLists.txt pins Boost and SWIG and both are looked up with an EXACT find_package(), while
-# Homebrew always installs the current formula. The day a formula moves ahead of the pin, every
-# Linux and macOS job fails at configure time - which is what the last SWIG bump was. This opens
-# the bump as a reviewable pull request the morning Homebrew publishes it, so the change arrives
-# deliberately instead of as a red build on somebody else's unrelated push.
-#
-# Only CMakeLists.txt is rewritten. It is the single source of truth for the build: the Windows
-# download URLs read the versions back out of it. The prerequisite documentation states the
-# versions in prose and is left to the reviewer, who is pointed at the exact places by the body of
-# the pull request.
-
 on:
   workflow_dispatch: {}
   schedule:
-    # Deliberately clear of the Dependabot window (01:00-03:00) and of
-    # build_with_quantlib_latest.yml at 01:23, so a failure here is easy to attribute.
     - cron: '37 4 * * *'
       timezone: "Europe/Berlin"
 
-# The pull request is opened with REPO_SCOPED_TOKEN, so the GITHUB_TOKEN only has to check the
-# repository out. Without this it would get the repository default, which is read-write.
 permissions:
   contents: read
 
@@ -30,15 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      # No submodules: only CMakeLists.txt is read and rewritten, and checking out QuantLib and
-      # QuantLib-SWIG would cost minutes for nothing.
       - uses: actions/checkout@v7
 
       - name: Compare the pinned versions with Homebrew
         id: compare
         run: |
-          # Assign first, then eval. 'eval "$(...)"' hides a failing command substitution from
-          # 'set -e', because eval of an empty string exits 0.
           brew_shellenv="$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           eval "${brew_shellenv}"
 
@@ -58,8 +39,6 @@ jobs:
             want="$(read_pin "${variable}")"
             have="$(brew info --json=v2 "${formula}" | jq -r '.formulae[0].versions.stable')"
 
-            # An unmatched pin or a renamed formula would otherwise write an empty version into
-            # CMakeLists.txt and open a pull request that breaks every job.
             if [ -z "${want}" ]; then
               echo "::error::Could not read ${variable} from CMakeLists.txt"
               exit 1
@@ -76,8 +55,6 @@ jobs:
 
             sed -i "s/\(${variable} \"\)[^\"]*\"/\1${have}\"/" CMakeLists.txt
 
-            # Confirm the rewrite landed rather than trusting sed: a pin whose formatting drifts
-            # from the pattern would leave the file untouched and open an empty pull request.
             if [ "$(read_pin "${variable}")" != "${have}" ]; then
               echo "::error::Failed to rewrite ${variable} in CMakeLists.txt"
               exit 1

--- a/.github/workflows/bump_toolchain_versions.yml
+++ b/.github/workflows/bump_toolchain_versions.yml
@@ -1,11 +1,21 @@
 name: Bump the pinned toolchain versions
 
+# CMakeLists.txt pins Boost and SWIG and both are looked up with an EXACT find_package(), while
+# Homebrew always installs the current formula. When a formula moves ahead of the pin, every
+# Linux and macOS job fails at configure time, so open the bump as a reviewable pull request.
+#
+# Only CMakeLists.txt is rewritten; it is the single source of truth for the pinned versions.
+# The prose in the prerequisite documentation is left to the reviewer.
+
 on:
   workflow_dispatch: {}
   schedule:
+    # Clear of the Dependabot window (01:00-03:00) and of build_with_quantlib_latest.yml at
+    # 01:23, so a failure here is easy to attribute.
     - cron: '37 4 * * *'
       timezone: "Europe/Berlin"
 
+# The pull request is opened with REPO_SCOPED_TOKEN, so GITHUB_TOKEN only has to check out.
 permissions:
   contents: read
 
@@ -15,11 +25,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      # No submodules: only CMakeLists.txt is read and rewritten.
       - uses: actions/checkout@v7
 
       - name: Compare the pinned versions with Homebrew
         id: compare
         run: |
+          # Assign first, then eval: 'eval "$(...)"' hides a failing command substitution from
+          # 'set -e', because eval of an empty string exits 0.
           brew_shellenv="$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           eval "${brew_shellenv}"
 
@@ -39,6 +52,8 @@ jobs:
             want="$(read_pin "${variable}")"
             have="$(brew info --json=v2 "${formula}" | jq -r '.formulae[0].versions.stable')"
 
+            # An unmatched pin or a renamed formula would otherwise write an empty version into
+            # CMakeLists.txt and open a pull request that breaks every job.
             if [ -z "${want}" ]; then
               echo "::error::Could not read ${variable} from CMakeLists.txt"
               exit 1
@@ -55,6 +70,8 @@ jobs:
 
             sed -i "s/\(${variable} \"\)[^\"]*\"/\1${have}\"/" CMakeLists.txt
 
+            # Confirm the rewrite landed rather than trusting sed: a pin whose formatting drifts
+            # from the pattern would leave the file untouched and open an empty pull request.
             if [ "$(read_pin "${variable}")" != "${have}" ]; then
               echo "::error::Failed to rewrite ${variable} in CMakeLists.txt"
               exit 1

--- a/.github/workflows/delete_workflow_caches.yml
+++ b/.github/workflows/delete_workflow_caches.yml
@@ -1,16 +1,5 @@
 name: Delete workflow caches
 
-# GitHub never reclaims the caches of a merged pull request or a deleted branch on its own, so they
-# keep counting against the 10GB repository quota until they are evicted. Once evicted, the entries
-# that are still in use go with them, and the next build recompiles from scratch.
-#
-# The pull request trigger is 'pull_request_target' and not 'pull_request': for a pull request from
-# a fork the 'pull_request' token stays read-only no matter what the workflow asks for in
-# 'permissions', and every deletion would fail with 403. Nothing from the pull request is checked
-# out or run here.
-#
-# 'workflow_dispatch' deletes the caches of one ref, or every cache of the repository when the input
-# is left empty.
 on:
   workflow_dispatch:
     inputs:
@@ -29,15 +18,6 @@ on:
 permissions:
   actions: write
 
-# Deleting the caches of one ref must not race a second run for the same ref. The group is keyed by
-# ref rather than by workflow: with a single repository-wide group, merging two pull requests in a
-# row cancels the queued run of the first one, and its caches are never deleted.
-#
-# Pick the ref by event, the same way CACHE_REF below does, instead of chaining '||' over the
-# contexts. 'ref' is also a top-level field of the workflow_dispatch payload - it holds the ref the
-# run was started from - so an unguarded '|| inputs.ref' is never reached on a manual run: every
-# dispatch grouped as the dispatching branch, and cleaning up two branches in a row cancelled the
-# queued second one.
 concurrency:
   group: >-
     ${{ github.workflow }}-${{ github.event_name == 'pull_request_target'
@@ -49,7 +29,6 @@ concurrency:
 jobs:
   delete-workflow-caches:
     name: Delete the workflow caches
-    # A deleted tag has no caches of its own; only branch deletions are worth a run.
     if: github.event_name != 'delete' || github.event.ref_type == 'branch'
     runs-on: ubuntu-latest
     steps:
@@ -64,10 +43,6 @@ jobs:
             || inputs.ref }}
         with:
           script: |
-            // The caches API matches a ref only in its fully qualified form: '?ref=master'
-            // answers 200 with an empty list while '?ref=refs/heads/master' returns the entries.
-            // A hand-typed branch name would therefore produce a green run that deleted nothing,
-            // so qualify anything that is not already a ref.
             const input = process.env.CACHE_REF;
             const ref = input && !input.startsWith('refs/')
               ? `refs/heads/${input}`
@@ -99,9 +74,6 @@ jobs:
                 });
                 core.info(`Deleted cache id ${cache.id} (${cache.key}).`);
               } catch (error) {
-                // Only a concurrent deletion of the same entry is harmless. Every other failure,
-                // a token without 'actions: write' above all, leaves the caches in place and must
-                // not pass as a green run that deleted nothing.
                 if (error.status === 404) {
                   core.info(`Cache id ${cache.id} (${cache.key}) was already deleted.`);
                 } else {

--- a/.github/workflows/delete_workflow_caches.yml
+++ b/.github/workflows/delete_workflow_caches.yml
@@ -1,5 +1,13 @@
 name: Delete workflow caches
 
+# GitHub never reclaims the caches of a merged pull request or a deleted branch, so they keep
+# counting against the 10GB quota until eviction takes the entries still in use with them.
+#
+# 'pull_request_target', not 'pull_request': a fork's 'pull_request' token stays read-only, so
+# every deletion would fail with 403. Nothing from the pull request is checked out or run here.
+#
+# 'workflow_dispatch' deletes the caches of one ref, or every cache when the input is empty.
+
 on:
   workflow_dispatch:
     inputs:
@@ -18,6 +26,11 @@ on:
 permissions:
   actions: write
 
+# Key the group by ref, not by workflow: with one repository-wide group, merging two pull
+# requests in a row cancels the queued run of the first and its caches are never deleted.
+#
+# Pick the ref by event, the same way CACHE_REF below does. 'inputs.ref' cannot be chained with
+# '||' because the workflow_dispatch payload has a top-level 'ref' of its own.
 concurrency:
   group: >-
     ${{ github.workflow }}-${{ github.event_name == 'pull_request_target'
@@ -29,6 +42,7 @@ concurrency:
 jobs:
   delete-workflow-caches:
     name: Delete the workflow caches
+    # A deleted tag has no caches of its own; only branch deletions are worth a run.
     if: github.event_name != 'delete' || github.event.ref_type == 'branch'
     runs-on: ubuntu-latest
     steps:
@@ -43,6 +57,8 @@ jobs:
             || inputs.ref }}
         with:
           script: |
+            // The caches API matches a ref only fully qualified: '?ref=master' answers 200 with
+            // an empty list, so qualify anything that is not already a ref.
             const input = process.env.CACHE_REF;
             const ref = input && !input.startsWith('refs/')
               ? `refs/heads/${input}`
@@ -74,6 +90,8 @@ jobs:
                 });
                 core.info(`Deleted cache id ${cache.id} (${cache.key}).`);
               } catch (error) {
+                // Only a concurrent deletion is harmless. Every other failure - a token without
+                // 'actions: write' above all - must not pass as a green run that deleted nothing.
                 if (error.status === 404) {
                   core.info(`Cache id ${cache.id} (${cache.key}) was already deleted.`);
                 } else {

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,8 @@
 name: Close stale issues and pull requests
 
+# Marks issues and pull requests stale after 60 days without activity and closes them 14 days
+# later. Milestones and the labels listed below are exempt.
+
 on:
   workflow_dispatch: {}
   schedule:


### PR DESCRIPTION
## Summary

- Remove every comment line from `.github/` and write the documentation again from
  scratch, so the wording is not carried forward from the previous rounds of edits.
  Net result is 98 lines of comments where there were 165 — roughly 40% shorter.
- Each comment now states *why* a construct is the way it is, in one or two lines
  instead of a paragraph:
  - `build_maven_artefact.yml` — deploy gating on `github.ref`, the job-name
    collision that branch protection depends on, and why the per-platform artifacts
    are deleted last (so `Re-run failed jobs` can still download them).
  - `build_native_libraries.yml` and `setup/action.yml` — why only the jdk17 job of a
    runner writes the compiler cache, why the restore key carries the architecture,
    and why `ccache-action` is pinned to a patch version.
  - `bump_toolchain_versions.yml` and `setup/action.yml` — the `EXACT`
    `find_package()` pins versus Homebrew's floating formulae, plus the guards around
    rewriting `CMakeLists.txt`.
  - `delete_workflow_caches.yml` — `pull_request_target` over `pull_request`, the
    ref-keyed concurrency group, and the caches API only matching fully qualified refs.
  - `env_variables/action.yml` and `setup/jdk/action.yml` — the heredoc `$GITHUB_ENV`
    write for the gpg passphrase, warn-don't-fail on a missing key so fork pull
    requests still run, and the version-keyed `setup-java` latch.
- Add short header comments to `dependabot.yml` (why there is one entry per directory)
  and `stale.yml` (what the timings do).

Split into two commits so the rewrite is reviewable: the first removes the old
comments, the second adds the new ones.

**No behaviour changes.** Every non-comment, non-blank line is byte-identical to
`master`.

## Test plan

- [x] Every file under `.github/` still parses as YAML
- [x] Stripping comments and blank lines from both `master` and this branch yields
      byte-identical files — the diff is comment-only
- [x] No line exceeds the 100 character limit from `.editorconfig`
- [ ] Actions run green on this pull request
